### PR TITLE
Use get-current-pull-request-action

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -2,13 +2,6 @@ name: Git Tag Semver From Label
 
 on:
   workflow_call:
-    inputs:
-      sha:
-        type: string
-        description: |
-          The commit SHA to tag. Defaults to the GITHUB_SHA.
-        required: false
-        default: ${{ github.sha }}
     secrets:
       github-token:
         description: |
@@ -29,16 +22,10 @@ jobs:
     permissions:
       pull-requests: read
     outputs:
-      pull-request: ${{ steps.get-current-pr.outputs.pr }}
+      pull-request: ${{ steps.get-current-pr.outputs.json }}
     steps:
       - id: get-current-pr
-        uses: 8BitJonny/gh-get-current-pr@2.2.0
-        with:
-          sha: ${{ inputs.sha }}
-      - if: ${{ steps.get-current-pr.outputs.pr_found == 'false' }}
-        run: |
-          echo "::error::no matching PR found!"
-          exit 1
+        uses: infrastructure-blocks/get-current-pull-request-action@v1
   check-has-semver-label:
     needs:
       - get-current-pr
@@ -57,6 +44,5 @@ jobs:
     uses: infrastructure-blocks/git-tag-semver-workflow/.github/workflows/workflow.yml@v1
     with:
       version: ${{ needs.check-has-semver-label.outputs.matched-label }}
-      sha: ${{ inputs.sha }}
     secrets:
       github-token: ${{ secrets.github-token }}

--- a/README.md
+++ b/README.md
@@ -18,9 +18,7 @@ PR comments will be emitted to notify the users or errors/notices/successes.
 
 ## Inputs
 
-| Name | Required | Description                                                                                                                                                                                                                                                                                                                               |
-|:----:|:--------:|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| sha  |  false   | The commit SHA to tag. Defaults to the ${{ github.sha }}. If the event triggering this workflow is of type pull_request, be sure to set this parameter to either ${{ github.event.pull_request.head.sha }} or ${{ github.event.pull_request.base.sha }}. You probably don't want to tag the PR's default SHA, which is on a merge branch. |
+N/A
 
 ## Secrets
 


### PR DESCRIPTION
- Closes #26
- Removed optional input sha. Normally, this would imply a major version change,
but since it is not used anywhere, we'll *SNEAK ATTACK* it.
